### PR TITLE
tailscale: separate config readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ If you're using a Raspberry Pi, then you will need the [64-bit OS](https://www.r
 ### Harden Your VPS
 * Harden via [./docs/vps_harden.md](./docs/vps_harden.md)
 
+### Configure Tailscale
+* Configure via [./docs/tailscale_configure.md](./docs/tailscale_configure.md)
+
 ### Deploy VPS Tunnel
 * Deploy via [./vps_tunnel/](./vps_tunnel/)
 

--- a/docs/tailscale_configure.md
+++ b/docs/tailscale_configure.md
@@ -1,0 +1,6 @@
+# Configure Tailscale
+
+* [Register](https://login.tailscale.com/start) for a Tailscale Account
+* `Enable MagicDNS` for Tailscale [here](https://login.tailscale.com/admin/dns)
+* Modify Tailscale ACL [here](https://login.tailscale.com/admin/acls)
+  * Replace `__YOUR_EMAIL__` in [./tailscale_acl.jsonc](./tailscale_acl.jsonc)

--- a/docs/vps_routing.md
+++ b/docs/vps_routing.md
@@ -1,12 +1,6 @@
 # Route 👤 -> `VPS` -> `Nginx` -> `Tailscale` -> `Nginx`
 
 
-### Configure Tailscale
-
-* Modify Tailscale ACL [here](https://login.tailscale.com/admin/acls)
-* Replace `__YOUR_EMAIL__` in the [./tailscale_acl.jsonc](./tailscale_acl.jsonc) config
-
-
 ### Configure `Nginx` -> `Tailscale` -> `Nginx`
 
 Reminder for how to access Nginx Proxy Manager on the VPS:

--- a/vps_tunnel/README.md
+++ b/vps_tunnel/README.md
@@ -4,8 +4,6 @@
 ### Prerequisites
 
 * Install [docker-compose](../docker_install.sh) on your VPS
-* [Register](https://login.tailscale.com/start) for a Tailscale Account
-* `Enable MagicDNS` for Tailscale [here](https://login.tailscale.com/admin/dns)
 
 
 ### Deploy Tunnel on VPS


### PR DESCRIPTION
split tailscale config into its own readme

this way we define the tailscale acl tags before (otherwise trying and failing) to use the tags